### PR TITLE
Fixup the Go method query

### DIFF
--- a/queries/go/nvimGPS.scm
+++ b/queries/go/nvimGPS.scm
@@ -13,3 +13,11 @@
 		(parameter_declaration
 			type: (type_identifier) @class-name))
 	name: (field_identifier) @method-name) @scope-root-2)
+
+; Method
+((method_declaration
+	receiver: (parameter_list
+		(parameter_declaration
+			type: (pointer_type 
+				(type_identifier)) @class-name))
+	name: (field_identifier) @method-name) @scope-root-2)


### PR DESCRIPTION
The Go query for a go method was missing a node within the query. This simply adds the necessary node﻿
