### PR TITLE
Add comma to configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ require("nvim-gps").setup({
 	languages = {
 		-- ["bash"] = false,
 		-- ["go"] = false,
-	}
+	},
 	separator = ' > ',
 })
 ```


### PR DESCRIPTION
The configuration is missing a comma and will cause an error if copied verbatim.