### PR TITLE
Python improvements

### DIFF
--- a/lua/nvim-gps/init.lua
+++ b/lua/nvim-gps/init.lua
@@ -130,7 +130,9 @@ function M.get_location()
 		if capture_node == node then
 			if gps_query.captures[capture_ID] == "scope-root" then
 
-				capture_ID, capture_node = iter()
+				while capture_node == node do
+					capture_ID, capture_node = iter()
+				end
 				local capture_name = gps_query.captures[capture_ID]
 				table.insert(node_text, 1, transform(capture_name, ts_utils.get_node_text(capture_node)[1]))
 

--- a/queries/python/nvimGPS.scm
+++ b/queries/python/nvimGPS.scm
@@ -3,6 +3,12 @@
 ((class_definition
 	name: (identifier) @class-name) @scope-root)
 
+; Method
+((function_definition
+	name: (identifier) @method-name
+	parameters: (parameters
+		(identifier) @self-capture (#eq? @self-capture "self"))) @scope-root)
+
 ; Function
 ((function_definition
 	name: (identifier) @function-name) @scope-root)

--- a/queries/python/nvimGPS.scm
+++ b/queries/python/nvimGPS.scm
@@ -16,4 +16,4 @@
 ; Main
 ((if_statement
 	condition: (comparison_operator
-		(string) @main-function (#match? @main-function "__main__") )) @scope-root)
+		(string) @main-function (#match? @main-function "[\"\']__main__[\"\']"))) @scope-root)


### PR DESCRIPTION
fix #18

Uses the `self` keyword to differentiate between regular functions and methods.
This is a bit hacky solution as the `method` query matches a subset of the `function` query, thus required some minor changes to the `get_location` function