### PR TITLE
Add YANG support

### DIFF
--- a/lua/nvim-gps/init.lua
+++ b/lua/nvim-gps/init.lua
@@ -171,6 +171,13 @@ local transform_lang = {
 		else
 			return default_transform(config, capture_name, capture_text)
 		end
+	end,
+	["yang"] = function(config, capture_name, capture_text)
+		if capture_name == "keyword" then
+			return nil
+		else
+			return default_transform(config, capture_name, capture_text)
+		end
 	end
 }
 
@@ -271,6 +278,18 @@ function M.get_data()
 	local node_data = {}
 	local node = current_node
 
+	function add_node_data(pos, capture_name, capture_node)
+		local node_text = transform(
+			config,
+			capture_name,
+			table.concat(ts_utils.get_node_text(capture_node), ' ')
+		)
+
+		if node_text ~= nil then
+			table.insert(node_data, pos, node_text)
+		end
+	end
+
 	while node do
 		local iter = gps_query:iter_captures(node, 0)
 		local capture_ID, capture_node = iter()
@@ -282,17 +301,17 @@ function M.get_data()
 					capture_ID, capture_node = iter()
 				end
 				local capture_name = gps_query.captures[capture_ID]
-				table.insert(node_data, 1, transform(config, capture_name, table.concat(ts_utils.get_node_text(capture_node), ' ')))
+				add_node_data(1, capture_name, capture_node)
 
 			elseif gps_query.captures[capture_ID] == "scope-root-2" then
 
 				capture_ID, capture_node = iter()
 				local capture_name = gps_query.captures[capture_ID]
-				table.insert(node_data, 1, transform(config, capture_name, table.concat(ts_utils.get_node_text(capture_node), ' ')))
+				add_node_data(1, capture_name, capture_node)
 
 				capture_ID, capture_node = iter()
 				capture_name = gps_query.captures[capture_ID]
-				table.insert(node_data, 2, transform(config, capture_name, table.concat(ts_utils.get_node_text(capture_node), ' ')))
+				add_node_data(1, capture_name, capture_node)
 
 			end
 		end

--- a/lua/nvim-gps/init.lua
+++ b/lua/nvim-gps/init.lua
@@ -15,18 +15,6 @@ local default_config = {
 		["container-name"] = 'ﮅ ',
 		["tag-name"] = '炙'
 	},
-	languages = {
-		["yang"] = {
-			icons = {
-				["container-name"] = "X",
-				["grouping-name"] = "X",
-				["typedef-name"] = "X",
-				["list-name"] = "X",
-				["leaf-list-name"] = "X",
-				["leaf-name"] = "X",
-			}
-		}
-	},
 	separator = ' > ',
 	depth = 0,
 	depth_limit_indicator = ".."
@@ -92,6 +80,20 @@ local function setup_language_configs()
 				["integer-name"] = '# ',
 				["float-name"] = ' ',
 				["string-name"] = ' '
+			}
+		}),
+		["yang"] = with_default_config({
+			icons = {
+				["module-name"] = " ",
+				["augment-path"] = " ",
+				["container-name"] = " ",
+				["grouping-name"] = " ",
+				["typedef-name"] = " ",
+				["identity-name"] = " ",
+				["list-name"] = "﬘ ",
+				["leaf-list-name"] = " ",
+				["leaf-name"] = " ",
+				["action-name"] = " ",
 			}
 		}),
 	}

--- a/lua/nvim-gps/init.lua
+++ b/lua/nvim-gps/init.lua
@@ -15,6 +15,18 @@ local default_config = {
 		["container-name"] = 'ﮅ ',
 		["tag-name"] = '炙'
 	},
+	languages = {
+		["yang"] = {
+			icons = {
+				["container-name"] = "X",
+				["grouping-name"] = "X",
+				["typedef-name"] = "X",
+				["list-name"] = "X",
+				["leaf-list-name"] = "X",
+				["leaf-name"] = "X",
+			}
+		}
+	},
 	separator = ' > ',
 	depth = 0,
 	depth_limit_indicator = ".."

--- a/queries/yang/nvimGPS.scm
+++ b/queries/yang/nvimGPS.scm
@@ -1,6 +1,10 @@
 ((module module_name: (identifier) @module-name) @scope-root)
 
 ((statement
+	(statement_keyword "augment")
+	(argument) @augment-path) @scope-root)
+
+((statement
 	(statement_keyword "container")
 	(argument) @container-name) @scope-root)
 
@@ -13,6 +17,10 @@
 	(argument) @typedef-name) @scope-root)
 
 ((statement
+	(statement_keyword "identity")
+	(argument) @identity-name) @scope-root)
+
+((statement
 	(statement_keyword "list")
 	(argument) @list-name) @scope-root)
 
@@ -23,3 +31,7 @@
 ((statement
 	(statement_keyword "leaf")
 	(argument) @leaf-name) @scope-root)
+
+((extension_statement
+	(extension_keyword) @keyword (#eq? @keyword "tailf:action")
+	(argument) @action-name) @scope-root-2)

--- a/queries/yang/nvimGPS.scm
+++ b/queries/yang/nvimGPS.scm
@@ -1,0 +1,25 @@
+((module module_name: (identifier) @module-name) @scope-root)
+
+((statement
+	(statement_keyword "container")
+	(argument) @container-name) @scope-root)
+
+((statement
+	(statement_keyword "grouping")
+	(argument) @grouping-name) @scope-root)
+
+((statement
+	(statement_keyword "typedef")
+	(argument) @typedef-name) @scope-root)
+
+((statement
+	(statement_keyword "list")
+	(argument) @list-name) @scope-root)
+
+((statement
+	(statement_keyword "leaf-list")
+	(argument) @leaf-list-name) @scope-root)
+
+((statement
+	(statement_keyword "leaf")
+	(argument) @leaf-name) @scope-root)


### PR DESCRIPTION
This pull request adds YANG support. My opinion is that for a language like YANG with deeply nested structures and a large amount of node types, using icons to represent the node types is not useful. Instead, this implementation shows the node type name directly. Here is an example:

![image](https://user-images.githubusercontent.com/597206/133961419-93067eee-ca2c-49ae-a473-2a489ef24ecc.png)

If icons should be used for the node types, there would have to be a large amount of different icons and they would have to be specific for YANG to be useful.