### PR TITLE
Add icons and separator per lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,24 @@ require("nvim-gps").setup({
 		["container-name"] = '⛶ ',  -- Containers (example: lua tables)
 		["tag-name"] = '炙'         -- Tags (example: html tags)
 	},
-	-- Disable any languages individually over here
+	-- Add custom configuration per language or
+	-- Disable the plugin for a language
 	-- Any language not disabled here is enabled by default
 	languages = {
-		-- ["bash"] = false,
-		-- ["go"] = false,
+		-- ["bash"] = false, -- disables nvim-gps for bash
+		-- ["go"] = false, -- disables nvim-gps for bash
+		-- ["ruby"] = {
+			separator = '|', -- Overrides default separator with '|'
+			icons = {
+				-- Default icons not specified in the lang config
+				-- will fallback to the default value
+				-- "container-name" will fallback to default because it's not set
+				["function-name"] = '',    -- to ensure empty values, set an empty string
+				["tag-name"] = ''
+				["class-name"] = '::',
+				["method-name"] = '#',
+			}
+		}
 	},
 	separator = ' > ',
 })


### PR DESCRIPTION
For ruby, I'd like to be able to see the location in ruby's standard format, like `::Namespace::Class#method`. My solution was to use the icons to define the proper separators and disable the _global_ separator. But, on the other hand, for other languages, like lua, I'd like to keep the default behavior. For this reason, I propose to enables the user to set icons and separator by language type, like:

```lua
gps.setup({
  separator = ' › ',
  icons = {
    ['class-name'] = ' ',
    ['function-name'] = ' ',
    ['method-name'] = ' ',
    ['container-name'] = ' ',
    ['tag-name'] = ' ',
  },
  languages = {
    cpp = false, -- disable the plugin for this language
    ruby = { -- add custom values for this language
      separator = '',
      icons = {
        -- ['container-name'] = '::', -- values not set will fallback to the global configuration and then to the default configuration
        ['class-name'] = '::',
        ['method-name'] = '#',
        ['tag-name'] = '', -- to avoid fallbacks to the global/default configuration the user can set emtpy values 
      },
    },
  },
})
```

<details>
<summary>Configuration used for examples </summary>
<img width="367" alt="_HOME__config_nvim_lua_plugins_treesitter_lua" src="https://user-images.githubusercontent.com/120483/135766515-6d7b9b3c-c9a2-4501-8bc2-43f988d4913f.png">
</details>

<details>
<summary>Example with custom icons and no separator (ruby)</summary>
<img width="313" alt="_private_tmp_a_rb" src="https://user-images.githubusercontent.com/120483/135766453-57cbf89b-dfcc-4f2c-8b45-58cd95f12dd9.png">
</details>

<details>
<summary>Example with the global configuration set (lua)</summary>
<img width="545" alt="_HOME__config_nvim_lua_plugins_treesitter_lua" src="https://user-images.githubusercontent.com/120483/135766466-6bfa9e33-f02e-4546-970e-1b8d45e885ce.png">
</details>




