### PR TITLE
feat: add support for toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Here is a example of how it can look in a fully configured statusline
 * Python
 * Ruby
 * Rust
+* TOML
 * Typescript (and tsx)
 * Verilog
 
@@ -104,6 +105,20 @@ require("nvim-gps").setup({
 				["boolean-name"] = 'ﰰﰴ ',
 				["number-name"] = '# ',
 				["string-name"] = ' '
+			}
+		},
+		["toml"] = {
+			icons = {
+				["table-name"] = ' ',
+				["array-name"] = ' ',
+				["boolean-name"] = 'ﰰﰴ ',
+				["date-name"] = ' ',
+				["date-time-name"] = ' ',
+				["float-name"] = ' ',
+				["inline-table-name"] = ' ',
+				["integer-name"] = '# ',
+				["string-name"] = ' ',
+				["time-name"] = ' '
 			}
 		},
 		["verilog"] = {

--- a/lua/nvim-gps/init.lua
+++ b/lua/nvim-gps/init.lua
@@ -52,6 +52,20 @@ local function setup_language_configs()
 				["string-name"] = ' '
 			}
 		}),
+		["toml"] = with_default_config({
+			icons = {
+				["table-name"] = ' ',
+				["array-name"] = ' ',
+				["boolean-name"] = 'ﰰﰴ ',
+				["date-name"] = ' ',
+				["date-time-name"] = ' ',
+				["float-name"] = ' ',
+				["inline-table-name"] = ' ',
+				["integer-name"] = '# ',
+				["string-name"] = ' ',
+				["time-name"] = ' '
+			}
+		}),
 		["verilog"] = with_default_config({
 			icons = {
 				["module-name"] = ' '

--- a/queries/toml/nvimGPS.scm
+++ b/queries/toml/nvimGPS.scm
@@ -1,0 +1,53 @@
+; Table
+((table
+	(_) @table-name) @scope-root)
+
+; Array
+((pair
+	(_) @array-name
+	(array)) @scope-root)
+
+; Boolean
+((pair
+	(_) @boolean-name
+	(boolean)) @scope-root)
+
+; Date
+((pair
+	(_) @date-name
+	(local_date)) @scope-root)
+
+; Date Time
+((pair
+	(_) @date-time-name
+	(offset_date_time)) @scope-root)
+
+((pair
+	(_) @date-time-name
+	(local_date_time)) @scope-root)
+
+; Float
+((pair
+	(_) @float-name
+	(float)) @scope-root)
+
+; Inline Table
+((pair
+	(_) @inline-table-name
+	(inline_table)) @scope-root)
+
+; Integer
+((pair
+	(_) @integer-name
+	(integer)) @scope-root)
+
+; String
+((pair
+	(_) @string-name
+	(string)) @scope-root)
+
+; Time
+((pair
+	(_) @time-name
+	(local_time)) @scope-root)
+


### PR DESCRIPTION
# Caveats:
Cannot get this to work with complicated scenarios such as:
```
[database]
temp_targets1 = { cpu = 79.5, case = 72.0 }
temp_targets2 = [{ cpu = 79.5, case = 72.0 }]
```
- Can only pick up `  database >   temp_targets1` and `  database >   temp_targets2 ` 
- Can't get `cpu` and `case`