### PR TITLE
Add direction isolate unicode markers around container icon

### DIFF
--- a/lua/nvim-gps/init.lua
+++ b/lua/nvim-gps/init.lua
@@ -12,7 +12,7 @@ local default_config = {
 		["class-name"] = ' ',
 		["function-name"] = ' ',
 		["method-name"] = ' ',
-		["container-name"] = 'ﮅ ',
+		["container-name"] = '⁦ﮅ⁩ ',
 		["tag-name"] = '炙'
 	},
 	separator = ' > ',


### PR DESCRIPTION
This adds the direction isolate markers to the right locations (they directly surround the container icon). This should fix any issues where this icon makes surrounding text sporadically switch to right to left, messing up terminals.