### PR TITLE
add zig support

### DIFF
--- a/queries/zig/nvimGPS.scm
+++ b/queries/zig/nvimGPS.scm
@@ -1,0 +1,13 @@
+; Struct
+((TopLevelDecl
+	(VarDecl
+		variable_type_function: (IDENTIFIER) @class-name)) @scope-root)
+
+; Function
+((TopLevelDecl
+	(FnProto
+		function: (IDENTIFIER) @function-name)) @scope-root)
+
+; Test
+((TestDecl
+	((STRINGLITERALSINGLE) @function-name)) @scope-root)


### PR DESCRIPTION
Adds queries for the Zig parser used by nvim-treesitter. Covers functions, tests, and global decls (structs, unions, ...).