### PR TITLE
Allow custom options argument in `get_location()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ table.insert(components.active[1], {
 	provider = function()
 		return gps.get_location()
 	end,
+	short_provider = function() -- truncates nvim-gps to depth 1 if it doesn't fit
+		return gps.get_location({ depth = 1 })
+	end,
 	enabled = function()
 		return gps.is_available()
 	end

--- a/lua/nvim-gps/init.lua
+++ b/lua/nvim-gps/init.lua
@@ -227,7 +227,7 @@ local update_tree = ts_utils.memoize_by_buf_tick(function(bufnr)
 	return parser:parse()
 end)
 
-function M.get_location()
+function M.get_location(opts)
 	-- Inserting text cause error nodes
 	if vim.fn.mode() == 'i' then
 		return cache_value
@@ -279,13 +279,17 @@ function M.get_location()
 		node = node:parent()
 	end
 
-	local context = table.concat(node_text, config.separator)
+	local depth = opts.depth or config.depth
+	local separator = opts.separator or config.separator
+	local depth_limit_indicator = opts.depth_limit_indicator or config.depth_limit_indicator
 
-	if config.depth ~= 0 then
-		local parts = vim.split(context, config.separator, true)
-		if #parts > config.depth then
-			local sliced = vim.list_slice(parts, #parts-config.depth+1, #parts)
-			context = config.depth_limit_indicator .. config.separator .. table.concat(sliced, config.separator)
+	local context = table.concat(node_text, separator)
+
+	if depth ~= 0 then
+		local parts = vim.split(context, separator, true)
+		if #parts > depth then
+			local sliced = vim.list_slice(parts, #parts - depth + 1, #parts)
+			context = depth_limit_indicator .. separator .. table.concat(sliced, separator)
 		end
 	end
 


### PR DESCRIPTION
This adds the option to pass an `opts` table to `get_location()` which overrides the default config that was set when calling `setup()`. This allows you to, for instance, call `get_location()` with a shorter depth as shown in the example config for feline.nvim that I added to `README.md`, with a truncated component version of nvim-gps.

The `opts` parameter allows you to override `depth`, `separator` and/or `depth_limit_indicator`.