### PR TITLE
fix: add better public class property support for TypeScript (#77)

### DIFF
--- a/queries/typescript/nvimGPS.scm
+++ b/queries/typescript/nvimGPS.scm
@@ -38,7 +38,8 @@
 			(string) @method-name
 			(arrow_function)))) @scope-root)
 
-; Arrow function methods
+; All public class properties
 ((public_field_definition
 	name: (property_identifier) @method-name
-	value: (arrow_function)) @scope-root)
+	value: (_)) @scope-root)
+


### PR DESCRIPTION
By using a [wildcard node](https://tree-sitter.github.io/tree-sitter/using-parsers#wildcard-node) it looks to cover all public class properties for TypeScript. Below is a before and after video.

As mentioned in #77 having better support for different public properties on the class can be handy for projects such as [NgRx Effects](https://ngrx.io/guide/effects)

Please let me know if there is anything else you would like me to do to clean this up. Thanks!


https://user-images.githubusercontent.com/1228424/156648803-d8da1fc4-82d0-4671-bfa8-19a5f1ced19a.mp4


https://user-images.githubusercontent.com/1228424/156648809-ce0f793d-ff83-4395-91b4-b5d06a60e236.mp4


