### PR TITLE
feat: add support for norg

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Here is a example of how it can look in a fully configured statusline
 * Javascript (and jsx)
 * JSON
 * Lua
+* Norg
 * Ocaml
 * Php
 * Python

--- a/lua/nvim-gps/init.lua
+++ b/lua/nvim-gps/init.lua
@@ -52,6 +52,11 @@ local function setup_language_configs()
 				["string-name"] = ' '
 			}
 		}),
+		["norg"] = with_default_config({
+			icons = {
+				["title-name"] = " ",
+			},
+		}),
 		["toml"] = with_default_config({
 			icons = {
 				["table-name"] = ' ',

--- a/queries/norg/nvimGPS.scm
+++ b/queries/norg/nvimGPS.scm
@@ -1,0 +1,24 @@
+;; Headings
+((heading1
+  (heading1_prefix)
+  title: (paragraph_segment) @title-name) @scope-root)
+
+((heading2
+  (heading2_prefix)
+  title: (paragraph_segment) @title-name) @scope-root)
+
+((heading3
+  (heading3_prefix)
+  title: (paragraph_segment) @title-name) @scope-root)
+
+((heading4
+  (heading4_prefix)
+  title: (paragraph_segment) @title-name) @scope-root)
+
+((heading5
+  (heading5_prefix)
+  title: (paragraph_segment) @title-name) @scope-root)
+
+((heading6
+  (heading6_prefix)
+  title: (paragraph_segment) @title-name) @scope-root)


### PR DESCRIPTION
It will capture the headings (up to level 6):

<img width="1920" alt="Screenshot 2022-03-28 at 9 56 35 PM" src="https://user-images.githubusercontent.com/35106942/160414748-3c1f9b3c-25d6-46df-ad2e-2082d6477515.png">

<img width="1920" alt="Screenshot 2022-03-28 at 9 56 43 PM" src="https://user-images.githubusercontent.com/35106942/160414771-c3c2e13e-f9a4-479d-b6f9-5cfc811923a3.png">

<img width="1920" alt="Screenshot 2022-03-28 at 9 56 52 PM" src="https://user-images.githubusercontent.com/35106942/160414790-32fdf71c-e645-4d4e-87a4-c1a37374132b.png">

