### PR TITLE
Make get_data() and get_location() returns nil if not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,11 +210,14 @@ nvim-gps doesn't modify your statusline by itself, instead you are provided with
 local gps = require("nvim-gps")
 
 gps.is_available()  -- Returns boolean value indicating whether a output can be provided
-gps.get_location()  -- Returns a string with context information
+gps.get_location()  -- Returns a string with context information (or nil if not available)
+
+-- example output: "mystruct > sum"
 ```
 
+
 <details>
-<summary> You can also pass optional arguments to <code>get_location</code> function to override options given in setup function </summary>
+<summary> You can also pass optional arguments to <code>get_location</code> function to override options given in setup function: </summary>
 
 ```lua
 opts = {
@@ -229,15 +232,15 @@ gps.get_location(opts)
 
 </details>
 
-These two functions should satisfy the needs of most users, however if you want the raw intermediate data for custom usage you can use the following function
+These two functions should satisfy the needs of most users, however if you want the raw intermediate data for custom usage you can use the following function:
 
 ```lua
-gps.get_data()      -- Returns an intermediate representation of data (which is used by get_location)
-					-- Table of tables that contain 'text', 'type' and 'icon' for each context
+gps.get_data()      -- Returns a table of intermediate representation of data (which is used by get_location)
+                    -- Table of tables that contain 'text', 'type' and 'icon' for each context
 ```
 
 <details>
-<summary> example output of <code>get_data</code> function </summary>
+<summary>An example output of <code>get_data</code> function: </summary>
 
 ```lua
  {
@@ -256,12 +259,14 @@ gps.get_data()      -- Returns an intermediate representation of data (which is 
 
 </details>
 
-Few examples below
+
+
+## Examples of Integrating with Other Plugins
 
 ### [feline](https://github.com/famiu/feline.nvim)
 
 <details>
-<summary> example feline setup </summary>
+<summary>An example feline setup </summary>
 
 ```lua
 -- Lua
@@ -282,7 +287,7 @@ table.insert(components.active[1], {
 ### [galaxyline](https://github.com/glepnir/galaxyline.nvim)
 
 <details>
-<summary> example galaxyline setup </summary>
+<summary>An example galaxyline setup </summary>
 
 ```lua
 -- Lua
@@ -305,7 +310,7 @@ require('galaxyline').section.left[1]= {
 ### [lualine](https://github.com/hoob3rt/lualine.nvim)
 
 <details>
-<summary> example lualine setup </summary>
+<summary>An example lualine setup </summary>
 
 ```lua
 -- Lua

--- a/lua/nvim-gps/init.lua
+++ b/lua/nvim-gps/init.lua
@@ -124,8 +124,8 @@ local function setup_language_configs()
 	}
 end
 
-local data_cache_value = ""
-local location_cache_value = ""
+local data_cache_value = nil  -- table
+local location_cache_value = ""  -- string
 local data_prev_loc = {0, 0}
 local location_prev_loc = {0, 0}
 local setup_complete = false
@@ -290,7 +290,7 @@ local update_tree = ts_utils.memoize_by_buf_tick(function(bufnr)
 	return parser:parse()
 end)
 
--- returns the data in table format
+---@return table|nil  the data in table format, or nil if gps is not available
 function M.get_data()
 	-- Inserting text cause error nodes
 	if vim.api.nvim_get_mode().mode == 'i' then
@@ -311,7 +311,7 @@ function M.get_data()
 	local config = configs[filelang]
 
 	if not gps_query then
-		return "error"
+		return nil
 	end
 
 	-- Request treesitter parser to update the syntax tree for the current buffer.
@@ -325,7 +325,7 @@ function M.get_data()
 	local function add_node_data(pos, capture_name, capture_node)
 		local text = ""
 
-		if vim.fn.has("nvim-0.7") then
+		if vim.fn.has("nvim-0.7") > 0 then
 			text = vim.treesitter.query.get_node_text(capture_node, 0)
 			text = string.gsub(text, "%s+", ' ')
 		else
@@ -386,7 +386,7 @@ function M.get_data()
 	return data_cache_value
 end
 
--- Returns the pretty statusline component
+---@return string|nil  the pretty statusline component, or nil if not available
 function M.get_location(opts)
 	if vim.api.nvim_get_mode().mode == 'i' then
 		return location_cache_value
@@ -402,6 +402,10 @@ function M.get_location(opts)
 	local filelang = ts_parsers.ft_to_lang(vim.bo.filetype)
 	local config = configs[filelang]
 	local data = M.get_data()
+
+	if not data then
+		return nil
+	end
 
 	local depth = config.depth
 	local separator = config.separator


### PR DESCRIPTION
The previous behavior of `get_data()` and `get_location()` when gps is
not available (e.g., when no available treesitter parsers/query) is
not well-defined; it could throw an error or return an "error" string.

As a result, users might have to first check whether `gps.is_available()`
and then call `get_location()` to get the actual string representation,
which is a little bit inconvenient.

This commit makes `get_data()` and `get_location()` return `nil` when
gps is not available (i.e., when no treesitter query is found).

This change can make practical usage more convenient, for example:

Before:

```lua
local function gps_location()
    gps = require "nvim-gps"
    return gps.is_available() and gps.get_location() or ""
end
```

After:

```lua
require "nvim-gps".get_location() or ""
```
