### PR TITLE
feat: add objects and arrays in javascript

### DIFF
--- a/lua/nvim-gps/init.lua
+++ b/lua/nvim-gps/init.lua
@@ -43,6 +43,12 @@ local configs = {}
 
 local function setup_language_configs()
 	configs = {
+		["javascript"] = with_default_config({
+			icons = {
+				["array-name"] = ' ',
+				["object-name"] = ' ',
+			}
+		}),
 		["json"] = with_default_config({
 			icons = {
 				["array-name"] = ' ',

--- a/queries/javascript/nvimGPS.scm
+++ b/queries/javascript/nvimGPS.scm
@@ -36,3 +36,39 @@
 ((field_definition
 	property: (property_identifier) @method-name
 	value: (arrow_function)) @scope-root)
+
+; object literal
+((variable_declarator
+	name: (identifier) @object-name
+	value: (object)) @scope-root)
+
+; object literal modification
+((assignment_expression
+	left: (identifier) @object-name
+	right: (object)) @scope-root)
+
+; nested objects
+((pair
+  key: (property_identifier) @object-name
+  value: (_)) @scope-root)
+
+; nested objects with computed_property_name e.g. { [bar] : true }
+((pair
+  key: (computed_property_name) @object-name
+  value: (_)) @scope-root)
+
+; object property modification
+((assignment_expression
+	left: (member_expression) @object-name
+	right: (object)) @scope-root)
+
+; array
+((variable_declarator
+	name: (identifier) @array-name
+	value: (array)) @scope-root)
+
+; array modification
+((assignment_expression
+	left: (identifier) @array-name
+	right: (array)) @scope-root)
+


### PR DESCRIPTION
#93 

Add queries for a few common shapes of arrays and objects.

```js
const foo = {
  bar: {
    baz: {
      bip: 'bop' // cursor on this line
    }
  }
}

{} foo > {} bar > {} baz > {} bip
```

```js
foo = {
  yabba: {
    dabba: {
      doo: 'wilma' // cursor on this line
    }
  }
}

{} foo > {} yabba > {} dabba > {} doo
```

```js
foo.zip = {
  zop: 'wow' // cursor on this line
}

{} foo.zip > {} zop
```

```js
const yo = [1,2,3] // cursor after `=`

[] yo
```

Some of these queries look very similar. I feel like there's probably some way to make these a bit more clever. For example, the `object literal` and `array` queries are identical besides the selector on `object` or `array`. 